### PR TITLE
双拼中的简拼支持

### DIFF
--- a/double_pinyin_flypy.custom.yaml
+++ b/double_pinyin_flypy.custom.yaml
@@ -63,7 +63,7 @@ patch:
     tags: abc
 
 
-#  "speller/algebra/@before 1": xform/^([b-df-hj-np-tv-z])$/$1_/
+ "speller/algebra/@before 1": xform/^([b-df-hj-np-tv-z])$/$1_/
 #  "speller/algebra/@before 2": derive/([ei])n$/$1ng/            # 模糊拼音 en => eng, in => ing
 #  "speller/algebra/@before 3": derive/([ei])ng$/$1n/            # 模糊拼音 eng => en, ing => in
 


### PR DESCRIPTION
你好，我在用你的方案自定义时，发现双拼方案中的简拼开关没有打开，建议能默认启用（在你的明月拼音方案中是默认启用的）。这个开关的效果如下：

在小鹤双拼下，原方案如果打`ufm`，只会弹出`shen`的联想，而不会弹出`shen m?`的联想（比如`什么`）。必须打完整`ufme`才会行。开启简拼后，单个声母也能触发联想，会方便很多。特别是句末经常出现“了”这个字，就再也不用敲`le`了。

另外这个开关不会让原本的双拼支持 `mypy`->`朙月拼音` 这种程度的简拼，造成误码。

最后，感谢你发布的这套配置，真的节省了我很多入门的时间。

FYI: 相关 [issue](https://github.com/rime/squirrel/issues/319)